### PR TITLE
Support arm and arm64 architectures

### DIFF
--- a/ioctl_14_2.go
+++ b/ioctl_14_2.go
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-// +build amd64 386
+// +build amd64 386 arm arm64
 
 package ioctl // import "acln.ro/ioctl"
 


### PR DESCRIPTION
Confirmed in arch/{arm,arm64}/include/uapi/asm/ that they do not
override _IOC_* constants.

Tested on arm at this time.